### PR TITLE
feat: added modifyCachedHtml and modifyGeneratedHtml callbacks to pro…

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ server.get('*',
 );
 ```
 with
+
 ```ts
 server.get('*',
   // Serve page if it exists in cache
@@ -61,6 +62,27 @@ server.get('*',
       { provide: CUSTOM_TOKEN, useValue: 'Hello from ISR' },
       CustomService
     ]
+  }),
+);
+```
+
+It is also possible to pass a `modifyCachedHtml` or `modifyGeneratedHtml` callbacks to the `ISRHandler` methods. 
+These methods provide a way to modify the html served from cache or the html that is generated on the fly.
+
+**Important:** Use these methods with caution as the logic written can increase the processing time.
+```ts
+server.get('*',
+  // Serve page if it exists in cache
+  async (req, res, next) => await isr.serveFromCache(req, res, next, {
+    modifyCachedHtml: (req, cachedHtml) => {
+        return `${cachedHtml}<!-- Hello, I'm a modification to the original cache! -->`;
+    }
+  }),
+  // Server side render the page and add to cache if needed
+  async (req, res, next) => await isr.render(req, res, next, {
+    modifyGeneratedHtml: (req, html) => {
+      return `${html}<!-- Hello, I'm modifying the generatedHtml before caching it! -->`
+    }
   }),
 );
 ```

--- a/angular.json
+++ b/angular.json
@@ -167,5 +167,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/projects/ngx-isr/src/lib/models/isr-handler-config.ts
+++ b/projects/ngx-isr/src/lib/models/isr-handler-config.ts
@@ -1,5 +1,6 @@
 import { Provider } from '@angular/core';
 import { CacheHandler } from "./cache-handler";
+import {Request} from 'express';
 
 export interface ISRHandlerConfig {
   cache?: CacheHandler; // instance of CacheHandler, default will be InMemoryCacheHandler
@@ -11,6 +12,13 @@ export interface ISRHandlerConfig {
 
 export interface ServeFromCacheConfig {
   providers?: Provider[];
+  /**
+   * This callback lets you hook into the cached html and provide any modifications
+   * necessary on-the-fly. This idea came with the need to listen to 'accept' header and
+   * modify the <html> tag to include classes that indicates support for webp/avif image formats, per-request.
+   * Use with caution as this may lead to a performance loss on serving the html.
+   */
+  modifyCachedHtml?: (req: Request, html: string) => string;
 }
 
 export interface InvalidateConfig {
@@ -19,4 +27,10 @@ export interface InvalidateConfig {
 
 export interface RenderConfig {
   providers?: Provider[];
+  /**
+   * This callback lets you hook into the generated html and provide any modifications
+   * necessary on-the-fly.
+   * Use with caution as this may lead to a performance loss on serving the html.
+   */
+  modifyGeneratedHtml?: (req: Request, html: string) => string;
 }


### PR DESCRIPTION
Hello @eneajaho,

I'm creating this PR to provide a way to `modify the generated html` and also `modify the cachedHtml` served with this library.

As much as the cache works perfectly, there are use cases where we want, per-request, to do little modifications on the served cachedHtml just like reacting to the `request` object's `accept` header and adding `webp` and/or `avif` classes to the `<html>` tag.

This enables a way to do this without resorting with javascript tricks on the browser side and also helps us serve better and more performant html to crawlers who support those images.

But this is only one example! The use cases can be limitless, it's never a bad thing to have a bit of flexibility :)

It's important to say that this PR does not break any previous implementation as this functionality is optional.

Thanks,

Renato