### PR TITLE
fix: modifyGeneratedHtml and modifyCachedHtml

### DIFF
--- a/projects/ngx-isr/src/lib/isr-handler.ts
+++ b/projects/ngx-isr/src/lib/isr-handler.ts
@@ -140,7 +140,8 @@ export class ISRHandler {
       let finalHtml = html;
       if(config?.modifyCachedHtml) {
         const timeStart = performance.now();
-        finalHtml = config.modifyCachedHtml(req, html);
+        const result = config.modifyCachedHtml(html);
+        finalHtml = result instanceof Promise ? await result : result;
         const totalTime = performance.now() - timeStart;
         finalHtml += `<!--\nℹ️ NgxISR: This cachedHtml has been modified with modifyCachedHtml()\n❗️ This resulted into more ${totalTime.toFixed(2)}ms of processing time.\n-->`;
       }
@@ -171,8 +172,12 @@ export class ISRHandler {
     renderUrl(renderUrlConfig).then(async (html) => {
       const { revalidate, errors } = getISROptions(html);
 
-      // Apply the callback if given
-      const finalHtml = config?.modifyGeneratedHtml ? config.modifyGeneratedHtml(req, html) : html;
+      // Apply modifyGeneratedHtml if given
+      let finalHtml = html;
+      if(config?.modifyGeneratedHtml) {
+         const result = config.modifyGeneratedHtml(html);
+         finalHtml = result instanceof Promise ? await result : result;
+      }
 
       // if we have any http errors when rendering the site, and we have skipCachingOnHttpError enabled
       // we don't want to cache it, and, we will fall back to client side rendering

--- a/projects/ngx-isr/src/lib/models/isr-handler-config.ts
+++ b/projects/ngx-isr/src/lib/models/isr-handler-config.ts
@@ -18,7 +18,7 @@ export interface ServeFromCacheConfig {
    * modify the <html> tag to include classes that indicates support for webp/avif image formats, per-request.
    * Use with caution as this may lead to a performance loss on serving the html.
    */
-  modifyCachedHtml?: (req: Request, html: string) => string;
+  modifyCachedHtml?: (html: string) => string | Promise<string>;
 }
 
 export interface InvalidateConfig {
@@ -32,5 +32,5 @@ export interface RenderConfig {
    * necessary on-the-fly.
    * Use with caution as this may lead to a performance loss on serving the html.
    */
-  modifyGeneratedHtml?: (req: Request, html: string) => string;
+  modifyGeneratedHtml?: (html: string) => string | Promise<string>;
 }


### PR DESCRIPTION
Hello again @eneajaho!

I'm making this PR because:

1. The `req` parameter on the modify html functions is redudant, we do already get it from the upperscope, leaving only `html: string` on those functions. This introduces an easy breaking change to refactor, just remove the 1st parameter and keep `html`.

2. I modified `modifyCachedHtml` and `modifyGeneratedHtml` to also accept Promises, since their methods on `ISRHandler` are Promises themselves. This doesn't introduce any breaking change at all.

Renato