### PR TITLE
Update example RedisCacheHandler to use a prefix

### DIFF
--- a/projects/ngx-isr-demo/server.ts
+++ b/projects/ngx-isr-demo/server.ts
@@ -30,7 +30,7 @@ export function app(): express.Express {
   // });
 
   const redisCacheHandler = REDIS_CONNECTION_STRING
-    ? new RedisCacheHandler(REDIS_CONNECTION_STRING)
+    ? new RedisCacheHandler({ connectionString: REDIS_CONNECTION_STRING })
     : undefined;
 
   // Step 1: Initialize ISRHandler


### PR DESCRIPTION
It is [conventional in Redis to prefix keys](https://stackoverflow.com/a/6971415/772859) to effectively "namespace" related keys. This change adds the ability to specify a key prefix, and defaults to `'ngx-isr'`.

This makes it much easier to deal with when using tools such as Redis Commander - see the screenshot comparing un-prefixed entries (orange) with prefixed ones (green): 
![image](https://user-images.githubusercontent.com/6275952/232081285-6e8f2c01-893c-4243-94bd-702708b5da71.png)
