### PR TITLE
fix: allow caching pages on different desk partitions

### DIFF
--- a/projects/ngx-isr/server/src/cache-handlers/filesystem-cache-handler.ts
+++ b/projects/ngx-isr/server/src/cache-handlers/filesystem-cache-handler.ts
@@ -244,8 +244,11 @@ export class FileSystemCacheHandler extends CacheHandler {
       //   newFilePath: '/Users/enea/Documents/GitHub/ngx-isr/dist/ngx-isr-demo/browser/cache/__details__1.html'
       // }
 
-      // move file to cache folder
-      fs.renameSync(path, newFilePath);
+      // copy file to cache folder
+      fs.copyFileSync(path, newFilePath);
+
+      // remove file from the browser folder so that it can be handled by ISR
+      fs.rmSync(path);
     }
 
     console.log(


### PR DESCRIPTION
Hello @eneajaho 

I ran into an issue using file system caching when deploying on AWS Lambda, file system write access is blocked on lambda so it's not possible to store the cache in the build directory, but they do provide a `/tmp` partition to store any thing on it. So I changed the caching directory path like this:

```typescript
const isRunningOnLambda = !!(process.env.LAMBDA_TASK_ROOT || process.env.AWS_EXECUTION_ENV);
const isrCacheFolderPath = isRunningOnLambda ? join('/tmp', '/isr-cache') : join(distFolder, '/isr-cache');
```
<br>

But now I got a new error message which is 
```
EXDEV: cross-device link not permitted, rename '/var/task/dist/browser/index.html' -> '/tmp/isr-cache/__.html'`
```
<br>

A bit cryptic, but it's coming from [filesystem-cache-handler.ts](https://github.com/eneajaho/ngx-isr/blob/v.0.5.4/projects/ngx-isr/src/lib/cache-handlers/filesystem-cache-handler.ts) at line 248
```typescript
fs.renameSync(path, newFilePath);
```
And after a bit of research it turns out `rename` doesn't allow renaming files across partitions so it fails.
<br>

The fix turns out to be fairly simple, all we have to is replace line 248 in [filesystem-cache-handler.ts](https://github.com/eneajaho/ngx-isr/blob/v.0.5.4/projects/ngx-isr/src/lib/cache-handlers/filesystem-cache-handler.ts) with: 
```typescript
fs.copyFileSync(path, newFilePath);
fs.rmSync(path);
```
<br>

I've already implemented a custom handler for my case but it would be awesome if I didn't have to do that, I also don't think consumers of the package should have to worry about low level details like this, so I've created this PR for it.
