### PR TITLE
fix: filesystem cache handler with url params #38

### DIFF
--- a/projects/ngx-isr/server/src/cache-handlers/filesystem-cache-handler.ts
+++ b/projects/ngx-isr/server/src/cache-handlers/filesystem-cache-handler.ts
@@ -336,8 +336,8 @@ function getFileFullPath(fileName: string, cacheFolderPath: string): string {
  * @returns {string} The modified string representing the file name obtained by replacing '/' characters with '__'.
  */
 function convertRouteToFileName(route: string): string {
-  // replace all occurrences of '/' character in the 'route' string with '__' using regular expression
-  return route.replace(new RegExp('/', 'g'), '__');
+  // replace all special characters in the 'route' string with '__' using regular expression
+  return route.replace(new RegExp('[^\w\d-]', 'g'), '__');
 }
 
 /**


### PR DESCRIPTION
Server crashes whenever trying to cache with `FileSystemCacheHandler` some route with url params, eg. `/search?term=test` or `/category/example?page=4` - might be problem on Windows only as mentioned in https://github.com/eneajaho/ngx-isr/issues/38 that you can't create file with special characters, but IMO in general it would be good to have more safe filenames. 

Basically replacing all special characters from route is fixing the main problem, in the future I will also take a look into angular prerendering itself (also breaks on special characters right now) and might need some changes to `convertFileNameToRoute` method as well. 

Solves https://github.com/eneajaho/ngx-isr/issues/38